### PR TITLE
[Application] HangulAtlasEditor 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ An awesome list of Hangul/Korean related libraries and modules.
 - [LaTeX](https://www.latex-project.org/)
   - [cjk-ko](https://github.com/dohyunkim/cjk-ko) - LaTeX에서 한글을 조판하고 한국어 문서를 작성하기 위한 패키지입니다.
 
+- Web application
+  - [HangulAtlasEditor](https://github.com/Creta5164/HangulAtlasEditor) - [BMFont](https://www.angelcode.com/products/bmfont)로 만든 폰트 아틀라스 텍스쳐 시트에 조합형 한글 시트를 합쳐주는 도구입니다.
+
 ## Use cases
 
 - [Design Efficient Keyboards for TV](https://story.pxd.co.kr/1441) used [Hangul.js](https://github.com/e-/Hangul.js) for separating consonants and vowels.


### PR DESCRIPTION
[BMFont](https://www.angelcode.com/products/bmfont)로 만들어지는 폰트 아틀라스에 조합형 한글을 합쳐주는 도구인 [HangulAtlasEditor](https://github.com/Creta5164/HangulAtlasEditor)를 추가합니다.

프레임워크를 기반으로 삼아서 개발되는 게임에서는, 화면에 글자를 표현하기 위해 [BMFont](https://www.angelcode.com/products/bmfont)를 이용해 글자가 그려진 스프라이트 시트 (폰트 아틀라스) 를 만들어서 글자를 표현합니다.

![og](https://github.com/Creta5164/HangulAtlasEditor/raw/master/og-image.png)

[도구를 사용하는 과정](https://youtu.be/-8ONj232ZVo)

[HangulAtlasEditor](https://github.com/Creta5164/HangulAtlasEditor)는 폰트 아틀라스에 들어간 한글을 조합형 한글 시트로 조합된 한글을 바꿔서 합쳐주는 도구입니다.  
이 도구를 웹에서 사용할 수 있게 만든 이유는 **복잡한 폰트 라이센스의 문제**와 **저해상도 한글 폰트가 너무 적었던 탓**에
저 뿐만 아니라 다른 게임 개발자분들에게도 한글을 쉽게 꾸미고 만들 수 있으면 좋지 않을까 싶어서 공개하게 됐습니다.

더 자세한 이야기는 아래의 블로그 포스트에서 읽어보실 수 있습니다.
https://blog.naver.com/hd3306/221985699526

